### PR TITLE
Update dolly.urdf

### DIFF
--- a/rover/urdf/dolly.urdf
+++ b/rover/urdf/dolly.urdf
@@ -21,7 +21,8 @@
       
     </collision>
   </link>
-
+    
+<link name="base_footprint"/>
   <joint name="base_joint" type="fixed">
     <parent link="base_footprint"/>
     <child link="base"/>


### PR DESCRIPTION
error is on line 25, where the joint "base_joint" refers to a link called "base_footprint" that is not defined in the URDF file.